### PR TITLE
removed requirement of error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For this assessment you'll be creating any sort of CRUD app. The app should be a
 4. Use at least one `has_many` relationship
 5. Must have user accounts. The user that created a given piece of content should be the only person who can modify that content
 6. You should validate user input to ensure that bad data isn't created
-7. Any validation failures must be shown to the user with an error message
+
 
 ### Example Domains
 


### PR DESCRIPTION
@PeterBell @AnnJohn would you be able to check this out and merge into master. I just removed the requirement for students to use error messages for the Sinatra CMS assessment.
